### PR TITLE
A single typo fix in the README

### DIFF
--- a/README
+++ b/README
@@ -141,4 +141,4 @@ DESCRIPTION
 
     distribution of this key among developers is outside the scope of the
     library.  encrypted email is likely the best mechanism for distribution,
-    but you've still got to sovle this problem for yourself ;-/
+    but you've still got to solve this problem for yourself ;-/


### PR DESCRIPTION
s/sovle/solve/
