### PR TITLE
Relax highline dependency to allow versions 1.6.X

### DIFF
--- a/lib/sekrets.rb
+++ b/lib/sekrets.rb
@@ -383,7 +383,7 @@ BEGIN {
       def dependencies
         {
           'openssl'  => [ 'openssl'  , ' ~> 3.2'   ] ,
-          'highline' => [ 'highline' , ' ~> 1.7'   ] ,
+          'highline' => [ 'highline' , ' ~> 1.6'   ] ,
           'map'      => [ 'map'      , ' ~> 6.6'   ] ,
           'fattr'    => [ 'fattr'    , ' ~> 2.4'   ] ,
           'coerce'   => [ 'coerce'   , ' ~> 0.0.8' ] ,

--- a/sekrets.gemspec
+++ b/sekrets.gemspec
@@ -38,19 +38,19 @@ Gem::Specification::new do |spec|
 
   spec.test_files = nil
 
-  
+
     spec.add_dependency(*["openssl", " ~> 3.2"])
-  
-    spec.add_dependency(*["highline", " ~> 1.7"])
-  
+
+    spec.add_dependency(*["highline", " ~> 1.6"])
+
     spec.add_dependency(*["map", " ~> 6.6"])
-  
+
     spec.add_dependency(*["fattr", " ~> 2.4"])
-  
+
     spec.add_dependency(*["coerce", " ~> 0.0.8"])
-  
+
     spec.add_dependency(*["main", " ~> 6.3"])
-  
+
 
   spec.extensions.push(*[])
 


### PR DESCRIPTION
Hey @ahoward 👋 

In the process of upgrading a legacy code base to ruby 3.1 I noticed an issue with sekrets/openssl. The code base is running sekrets 1.13 and I noticed that sekrets 1.14 would fix the issue.

Unfortunately sekrets 1.14 also bumped the highline dependency from 1.6 to 1.7 and our code base has a hard dependency on highline 1.6, so we currently cannot use sekrets 1.14.

With this PR I propose to relax the highline dependency to allow for highline versions 1.6.X again. My reasons for doing so are (besides being more "inclusive" and allowing us to use 1.14 😉):

- sekrets does not depend on any added functionality in highline 1.7
- highline 1.7 did not fix any security issues present in 1.6 that would make an upgrade "mandatory"

In general I think gems should be as loose as possible with dependencies on other gems. 

Let me know if this makes sense to you!